### PR TITLE
patch to v3: Parsing test now allow non-array format YAML

### DIFF
--- a/lib/metadata_hook.rb
+++ b/lib/metadata_hook.rb
@@ -11,7 +11,40 @@ class SqliteMetadataHook < Mumukit::Hook
       },
       test_framework: {
         name: 'metatest',
-        test_extension: 'yml'
+        test_extension: 'yml',
+        template: <<YAML
+# El siguiente es un ejemplo de cómo generar test para SQL utilizando formato YAML.
+# Acá dejamos los tres tipos de tests que podés escribir.
+# Para info más detallada revisá la wiki: https://github.com/mumuki/mumuki-sqlite-runner/wiki
+
+# 1. query
+- type: query
+  seed: | # Opcional
+    INSERT INTO table VALUES ('dato 1');
+    INSERT INTO table VALUES ('dato 2');
+  expected: SELECT * FROM table;
+# 2. datasets
+- type: datasets
+  seed: | # Opcional
+    INSERT INTO table VALUES ('dato 1');
+    INSERT INTO table VALUES ('dato 2');
+  expected: |
+    id|descrip
+    1|dato 1
+    2|dato 2
+# 3. final_dataset
+- type: final_dataset
+  seed: | # Opcional
+    INSERT INTO table VALUES ('dato 1');
+    INSERT INTO table VALUES ('dato 2');
+  final: SELECT descrip FROM bolitas;
+  # Supongamos que el ejercicio pide insertar 'dato 3'
+  expected: |
+    descrip
+    dato 1
+    dato 2
+    dato 3
+YAML
       }
     }
   end

--- a/lib/metadata_hook.rb
+++ b/lib/metadata_hook.rb
@@ -12,7 +12,13 @@ class SqliteMetadataHook < Mumukit::Hook
       test_framework: {
         name: 'metatest',
         test_extension: 'yml',
-        template: <<YAML
+        template: template
+      }
+    }
+  end
+
+  def template
+    <<YAML
 # El siguiente es un ejemplo de cómo generar test para SQL utilizando formato YAML.
 # Acá dejamos los tres tipos de tests que podés escribir.
 # Para info más detallada revisá la wiki: https://github.com/mumuki/mumuki-sqlite-runner/wiki
@@ -45,7 +51,5 @@ class SqliteMetadataHook < Mumukit::Hook
     dato 2
     dato 3
 YAML
-      }
-    }
   end
 end

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -134,6 +134,7 @@ class SqliteTestHook < Mumukit::Templates::FileHook
   #     ...
   def parse_tests(tests)
     tests = YAML.load tests
+    tests = [tests] unless tests.kind_of? Array
     @tests = tests.map do | test |
       test = test.to_struct
       @test_parsers[test.type.to_sym].new test

--- a/spec/data/00006_final_dataset2.yml
+++ b/spec/data/00006_final_dataset2.yml
@@ -5,19 +5,19 @@ statement:
       color varchar(200) NOT NULL
     );
   test:
-    - type: final_dataset
-      seed: |
-        INSERT INTO bolitas (color) values ('Verde');
-        INSERT INTO bolitas (color) values ('Rojo');
-        INSERT INTO bolitas (color) values ('Azul');
-        INSERT INTO bolitas (color) values ('Negro');
-      final: SELECT color, hex FROM bolitas;
-      expected: |
-        color|hex
-        Verde|#00FF00
-        Rojo|#FF0000
-        Azul|#0000FF
-        Negro|#000000
+    type: final_dataset
+    seed: |
+      INSERT INTO bolitas (color) values ('Verde');
+      INSERT INTO bolitas (color) values ('Rojo');
+      INSERT INTO bolitas (color) values ('Azul');
+      INSERT INTO bolitas (color) values ('Negro');
+    final: SELECT color, hex FROM bolitas;
+    expected: |
+      color|hex
+      Verde|#00FF00
+      Rojo|#FF0000
+      Azul|#0000FF
+      Negro|#000000
   count: 1
 solution:
   valid: |


### PR DESCRIPTION
When someone write test in YAML, it is mandatory to write it as array format:

```YAML
- type: datasets
  seed: ...
  expected: ...
```

But when you only need one test, it's nice not to write `-` and _tabs_.

So, with this patch you can write single test like:

```YAML
type: datasets
seed: ...
expected: ...
```
