### PR TITLE
Table result using mu-sql-table-rendered class

### DIFF
--- a/lib/html_renderer.rb
+++ b/lib/html_renderer.rb
@@ -5,6 +5,7 @@ module Sqlite
 
     def render_success(result, message)
       @message = message
+      @table_name = result[:table_name]
       @header  = result[:dataset].header
       @rows    = result[:dataset].rows
       @extra_message = extra_message result
@@ -13,6 +14,7 @@ module Sqlite
 
     def render_error(result, solution, error)
       @error = error
+      @table_name = result[:table_name]
       @result = parse_dataset(result[:dataset].header, result[:dataset].rows)
       @solution = parse_dataset(solution[:dataset].header, solution[:dataset].rows)
       @expected_message = expected_message result

--- a/lib/html_renderer.rb
+++ b/lib/html_renderer.rb
@@ -6,8 +6,8 @@ module Sqlite
     def render_success(result, message)
       @message = message
       @table_name = result[:table_name]
-      @header  = result[:dataset].header
-      @rows    = result[:dataset].rows
+      @header = result[:dataset].header
+      @rows = result[:dataset].rows
       @extra_message = extra_message result
       template_file_success.result binding
     end
@@ -25,10 +25,10 @@ module Sqlite
     protected
 
     def parse_dataset(header, rows)
-      header_sign = header.shift
+      header_sign = first_column(header)
       rows = rows.map do |row|
         {
-            sign: row.shift,
+            sign: first_column(row),
             row: row
         }
       end
@@ -41,13 +41,17 @@ module Sqlite
           },
           rows: rows.map do |row|
             {
-                sign:row[:sign],
+                sign: row[:sign],
                 class: diff_class_of(row[:sign]),
                 fields: row[:row]
             }
           end
       }
 
+    end
+
+    def first_column(row)
+      row.first.present? && row.first =~ /^[+-]$/ ? row.shift : ''
     end
 
     def diff_class_of(value)

--- a/lib/html_renderer.rb
+++ b/lib/html_renderer.rb
@@ -51,7 +51,7 @@ module Sqlite
     end
 
     def first_column(row)
-      row.first.present? && row.first =~ /^[+-]$/ ? row.shift : ''
+      row.first.present? && row.first =~ /^[+-]$/ ? row.shift : '✓'
     end
 
     def diff_class_of(value)

--- a/lib/locales/en.yml
+++ b/lib/locales/en.yml
@@ -1,5 +1,6 @@
 en:
   dataset: "Dataset %{number}"
+  default_table_name: 'Result'
   expected: 'It was expected:'
   obtained: 'It was obtained:'
   message:

--- a/lib/locales/es.yml
+++ b/lib/locales/es.yml
@@ -1,5 +1,6 @@
 es:
   dataset: "Set de datos %{number}"
+  default_table_name: 'Resultado'
   expected: 'Se esperaba:'
   obtained: 'Se obtuvo:'
   message:

--- a/lib/parsers/base_parser.rb
+++ b/lib/parsers/base_parser.rb
@@ -30,6 +30,10 @@ module Sqlite
       false
     end
 
+    def table_name
+      has?(:result_alias) ? get(:result_alias) : I18n.t('default_table_name')
+    end
+
     protected
 
     def transform_test

--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -86,6 +86,7 @@ class SqliteTestHook < Mumukit::Templates::FileHook
       {
           id: i + 1,
           dataset: Sqlite::Dataset.new(dataset),
+          table_name: @tests[i].table_name,
           show_query: @tests[i].show_query?,
           query: @tests[i].get_final_query
       }

--- a/lib/view/rows_error.html.erb
+++ b/lib/view/rows_error.html.erb
@@ -47,26 +47,29 @@
   <!-- Solution -->
   <div class="col-md-6">
     <h6><%= @obtained_message %></h6>
-    <header><%= @table_name %></header>
-    <table>
-      <thead>
-      <tr class="<%= @result[:header][:class] %>">
-        <th><%= @result[:header][:sign] %></th>
-        <% @solution[:header][:fields].each do |field| %>
-            <th><%= field %></th>
+    
+    <div class="mu-sql-table-rendered">
+      <header><%= @table_name %></header>
+      <table>
+        <thead>
+        <tr class="<%= @result[:header][:class] %>">
+          <th><%= @result[:header][:sign] %></th>
+          <% @solution[:header][:fields].each do |field| %>
+              <th><%= field %></th>
+          <% end %>
+        </tr>
+        </thead>
+        <tbody>
+        <% @solution[:rows].each do |row| %>
+            <tr class="<%= row[:class] %>">
+              <td><%= row[:sign] %></td>
+              <% row[:fields].each do |field| %>
+                  <td><%= field %></td>
+              <% end %>
+            </tr>
         <% end %>
-      </tr>
-      </thead>
-      <tbody>
-      <% @solution[:rows].each do |row| %>
-          <tr class="<%= row[:class] %>">
-            <td><%= row[:sign] %></td>
-            <% row[:fields].each do |field| %>
-                <td><%= field %></td>
-            <% end %>
-          </tr>
-      <% end %>
-      </tbody>
-    </table>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>

--- a/lib/view/rows_error.html.erb
+++ b/lib/view/rows_error.html.erb
@@ -18,7 +18,7 @@
     <h6><%= @expected_message %></h6>
 
     <div class="mu-sql-table-rendered">
-      <header><% @table_name %></header>
+      <header><%= @table_name %></header>
       <table>
         <thead>
         <tr class="<%= @result[:header][:class] %>">
@@ -47,7 +47,7 @@
   <!-- Solution -->
   <div class="col-md-6">
     <h6><%= @obtained_message %></h6>
-    <header><% @table_name %></header>
+    <header><%= @table_name %></header>
     <table>
       <thead>
       <tr class="<%= @result[:header][:class] %>">

--- a/lib/view/rows_error.html.erb
+++ b/lib/view/rows_error.html.erb
@@ -1,29 +1,4 @@
 <style>
-  table.sqlite_error {
-    width: auto;
-  }
-  table.sqlite_result {
-    border: none;
-  }
-  table.sqlite_solution {
-    border: none;
-  }
-  table.sqlite_error tr:nth-child(even) {
-    background-color: #EEEEEE;
-  }
-  table.sqlite_error tr:nth-child(odd) {
-    background-color: #FFFFFF;
-  }
-  table.sqlite_error th {
-    color: white;
-    font-weight: bold;
-    background-color: #2E2F30;
-  }
-  table.sqlite_error td {
-    width: auto;
-    text-align: left;
-  }
-
   .required {
     color: #5cb85c;
     font-style: italic;
@@ -31,25 +6,6 @@
   .errored {
     color: #d9534f;
     font-style: italic;
-  }
-
-  .required :first-child,
-  .errored :first-child,
-  .nothing :first-child {
-    font-style: normal;
-    padding-left: 2px;
-    padding-right: 2px;
-    background-color: white;
-    border-left: none;
-    border-bottom: 1px solid white;
-  }
-  .required :first-child {
-    color: white;
-    background-color: #5cb85c;
-  }
-  .errored :first-child {
-    color: white;
-    background-color: #d9534f;
   }
 </style>
 
@@ -60,33 +16,39 @@
   <!-- Result -->
   <div class="col-md-6">
     <h6><%= @expected_message %></h6>
-    <table class="table table-bordered sqlite_error sqlite_result">
-      <thead>
-      <tr class="<%= @result[:header][:class] %>">
-        <th><%= @result[:header][:sign] %></th>
-        <% @result[:header][:fields].each do |field| %>
-            <th><%= field %></th>
-        <% end %>
-      </tr>
-      </thead>
 
-      <tbody>
-      <% @result[:rows].each do |row| %>
-          <tr class="<%= row[:class] %>">
-            <td><%= row[:sign] %></td>
-            <% row[:fields].each do |field| %>
-                <td><%= field %></td>
-            <% end %>
-          </tr>
-      <% end %>
-      </tbody>
-    </table>
+    <div class="mu-sql-table-rendered">
+      <header><% @table_name %></header>
+      <table>
+        <thead>
+        <tr class="<%= @result[:header][:class] %>">
+          <th><%= @result[:header][:sign] %></th>
+          <% @result[:header][:fields].each do |field| %>
+              <th><%= field %></th>
+          <% end %>
+        </tr>
+        </thead>
+        <tbody>
+        <% @result[:rows].each do |row| %>
+            <tr class="<%= row[:class] %>">
+              <td><%= row[:sign] %></td>
+              <% row[:fields].each do |field| %>
+                  <td><%= field %></td>
+              <% end %>
+            </tr>
+        <% end %>
+        </tbody>
+      </table>
+    </div>
+
+
   </div>
 
   <!-- Solution -->
   <div class="col-md-6">
     <h6><%= @obtained_message %></h6>
-    <table class="table table-bordered sqlite_error sqlite_solution">
+    <header><% @table_name %></header>
+    <table>
       <thead>
       <tr class="<%= @result[:header][:class] %>">
         <th><%= @result[:header][:sign] %></th>
@@ -95,7 +57,6 @@
         <% end %>
       </tr>
       </thead>
-
       <tbody>
       <% @solution[:rows].each do |row| %>
           <tr class="<%= row[:class] %>">
@@ -109,5 +70,3 @@
     </table>
   </div>
 </div>
-
-

--- a/lib/view/rows_success.html.erb
+++ b/lib/view/rows_success.html.erb
@@ -1,45 +1,26 @@
-<style>
-  table.sqlite_success {
-    width: auto;
-    border: none;
-  }
-  table.sqlite_success tr:nth-child(even) {
-    background-color: #DDDDDD;
-  }
-  table.sqlite_success tr:nth-child(odd) {
-    background-color: #FFFFFF;
-  }
-  table.sqlite_success th {
-    color: white;
-    font-weight: bold;
-    background-color: #BBBBBB;
-  }
-  table.sqlite_success td {
-    width: auto;
-    text-align: left;
-  }
-</style>
-
 <h5><%= message %></h5>
 <% if @extra_message %>
   <h6><%= @extra_message %></h6>
 <% end %>
-<table class="table table-bordered sqlite_success">
-  <thead>
-  <tr>
-  <% @header.each do |field| %>
-    <th><%= field %></th>
-  <% end %>
-  </tr>
-  </thead>
 
-  <tbody>
-  <% @rows.each do |row| %>
-      <tr>
-      <% row.each do |field| %>
-        <td><%= field %></td>
+<div class="mu-sql-table-rendered">
+  <header><% @table_name %></header>
+  <table>
+    <thead>
+    <tr>
+      <% @header.each do |field| %>
+          <th><%= field %></th>
       <% end %>
-      </tr>
-  <% end %>
-  </tbody>
-</table>
+    </tr>
+    </thead>
+    <tbody>
+    <% @rows.each do |row| %>
+        <tr>
+          <% row.each do |field| %>
+              <td><%= field %></td>
+          <% end %>
+        </tr>
+    <% end %>
+    </tbody>
+  </table>
+</div>

--- a/lib/view/rows_success.html.erb
+++ b/lib/view/rows_success.html.erb
@@ -4,7 +4,7 @@
 <% end %>
 
 <div class="mu-sql-table-rendered">
-  <header><% @table_name %></header>
+  <header><%= @table_name %></header>
   <table>
     <thead>
     <tr>

--- a/mumuki-sqlite-runner.gemspec
+++ b/mumuki-sqlite-runner.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'dotenv'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'codeclimate-test-reporter'
-  spec.add_development_dependency 'mumukit-bridge', '~> 1.3'
+  spec.add_development_dependency 'mumukit-bridge', '~> 3.1'
 end

--- a/spec/html_renderer_spec.rb
+++ b/spec/html_renderer_spec.rb
@@ -14,8 +14,6 @@ describe Sqlite::HtmlRenderer do
     end
 
     it { expect(render).to include I18n.t 'message.success.query' }
-    it { expect(render).to include 'sqlite_success' }
-    it { expect(render).not_to include 'sqlite_error' }
   end
 
   describe '#render_error' do
@@ -33,8 +31,6 @@ describe Sqlite::HtmlRenderer do
     end
 
     it { expect(render).to include error }
-    it { expect(render).to include 'sqlite_error' }
-    it { expect(render).not_to include 'sqlite_success' }
   end
 
 end


### PR DESCRIPTION
Now both result tables (success & error) uses `mu-sql-table-rendered-class` as discussed in #19 

I could not see it in a browser, I just changed html and some stuff in rendered.

I also added the possibility to use the key _result_alias_ in YAML test to define table name.