### PR TITLE
Make column name comparison case-insensitive

### DIFF
--- a/lib/dataset.rb
+++ b/lib/dataset.rb
@@ -35,7 +35,7 @@ module Sqlite
     end
 
     def same_header(other_header)
-      @header.eql? other_header
+      @header.map(&:downcase).eql? other_header.map(&:downcase)
     end
 
     def same_rows(other_rows)

--- a/spec/dataset_spec.rb
+++ b/spec/dataset_spec.rb
@@ -25,6 +25,18 @@ describe Sqlite::Dataset do
       expect(solution.compare result).to eq :equals
     end
 
+    it 'should be equals when has same columns & same rows in same order, but different case' do
+      result = <<~ROWS
+        id|NAME
+        1|Name 1
+        2|Name 2
+        3|Name 3
+      ROWS
+      result = Sqlite::Dataset.new result
+
+      expect(solution.compare result).to eq :equals
+    end
+
     # :distinct_columns
     it 'should has distinct columns when result has less columns than solution' do
       result = <<~ROWS


### PR DESCRIPTION
# :dart: Goal

To make column name comparison case-insensitive. SQL is a case-insensitive language and therefore column names should be compared ignoring case.

