### PR TITLE
Normalize student + expected result headers before diff

### DIFF
--- a/lib/test_hook.rb
+++ b/lib/test_hook.rb
@@ -49,7 +49,18 @@ class SqliteTestHook < Mumukit::Templates::FileHook
     expected.map!.with_index do |expect, i|
       @tests[i].choose_solution expect
     end
+    student = normalize_headers(student)
+    expected = normalize_headers(expected)
     diff(expected, student)
+  end
+
+  def normalize_headers(results)
+    results.map do |result|
+      headers, *rows = result.split("\n")
+
+      headers.downcase!
+      [headers, *rows].join("\n")
+    end
   end
 
   # Make diff between expected and student dataset result and mark each line one according comparision

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -92,6 +92,34 @@ describe 'SqliteTestHook as isolated FileHook' do
       expect(post_process[1]).to eq :failed
       expect(post_process[0]).to eq 'Error near something'
     end
+
+    it 'is case insensitive for headers row' do
+      result = {
+        expected: ['solution 1'],
+        student:  ['SoLuTiOn 1']
+      }
+
+      runner.compile_file_content(request)
+      post_process = runner.post_process_file('', result.to_json, :passed)
+
+      expect(post_process[0][0][0]).to eq I18n.t :dataset, number: 1
+      expect(post_process[0][0][1]).to eq :passed
+      expect(post_process[0][0][2]).to include I18n.t 'message.success.query'
+    end
+
+    it 'is not case insensitive for other rows' do
+      result = {
+        expected: ["solution 1\ntest"],
+        student:  ["solution 1\nTest"]
+      }
+
+      runner.compile_file_content(request)
+      post_process = runner.post_process_file('', result.to_json, :passed)
+
+      expect(post_process[0][0][0]).to eq I18n.t :dataset, number: 1
+      expect(post_process[0][0][1]).to eq :failed
+      expect(post_process[0][0][2]).to include I18n.t 'message.failure.rows'
+    end
   end
 
   describe '#run!' do


### PR DESCRIPTION
## :dart: Goal
Make runner case insensitive for columns.

## :memo: Details
@flbulgarelli took a stab at this problem in https://github.com/mumuki/mumuki-sqlite-runner/pull/29.
Problem is, the compare logic is executed _after_ diff is done between student and expected results, which meant diff would be something like `+ COUNT(*)` vs `- count(*)`. Even if columns are downcased by then headers are not equal because of the `+` and `-` symbols.

## :warning: Dependencies
None.

## :back: Backwards compatibility
Yes.

## :soon: Future work
Need to add tests.